### PR TITLE
Split out notebook exec requirements from dev reqs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ mypy:
 
 notebooks:=$(wildcard notebooks/*.py)
 $(notebooks): clean lint mypy
-	docker exec $(CONTAINER) bash -c "$(LEO_PIP) install --upgrade -r $(CONTAINER_REPO_DIR)/requirements.txt"
+	docker exec $(CONTAINER) bash -c "$(LEO_PIP) install --upgrade -r $(CONTAINER_REPO_DIR)/requirements-notebooks.txt"
 	docker exec -it $(CONTAINER) $(LEO_PYTHON) $(CONTAINER_REPO_DIR)/$@
 	$(CALLYSTO) $(LOCAL_ROOT_DIR)/$@ > $(LOCAL_ROOT_DIR)/$(@:.py=.ipynb)
 	scripts/publish.sh $(LOCAL_ROOT_DIR)/$@ $(LOCAL_ROOT_DIR)/$(@:.py=.ipynb)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,3 @@
 flake8
 mypy
 git+https://github.com/xbrianh/callysto
-terra-notebook-utils

--- a/requirements-notebooks.txt
+++ b/requirements-notebooks.txt
@@ -1,0 +1,2 @@
+terra-notebook-utils
+git+https://github.com/xbrianh/callysto


### PR DESCRIPTION
notebook-requirements.txt will be installed into the docker
container during notebook execution.