### PR TITLE
Inject gcloud credentials into Docker container

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,6 @@ $(notebooks): clean lint mypy
 	docker exec $(CONTAINER) bash -c "$(LEO_PIP) install --upgrade -r $(CONTAINER_REPO_DIR)/requirements-notebooks.txt"
 	docker exec -it $(CONTAINER) $(LEO_PYTHON) $(CONTAINER_REPO_DIR)/$@
 	$(CALLYSTO) $(LOCAL_ROOT_DIR)/$@ > $(LOCAL_ROOT_DIR)/$(@:.py=.ipynb)
-	docker exec -it $(CONTAINER) gcloud auth login
 	docker exec -it $(CONTAINER) $(CONTAINER_REPO_DIR)/scripts/publish.sh $(CONTAINER_REPO_DIR)/$@ $(CONTAINER_REPO_DIR)/$(@:.py=.ipynb)
 
 clean:

--- a/README.md
+++ b/README.md
@@ -41,10 +41,15 @@ gcloud auth login
 
 ## Authorization for Testing and Publishing
 
-Depending on the content of the notebook, Google application credentials may be required. They can be obtained with the command
+Google user credentials are required to publish notebooks to Terra workspaces. Additinally, notebook execution may
+require Google application default credentials. Both sets can be obtained by executing the commmads
 ```
+gcloud auth login
 gcloud auth application-default login
 ```
+
+Credentials are injected into the local Docker container when testing and publishing notebooks, and are expected to be
+in the standard location `~/.config`.
 
 ## Local Development Environment
 

--- a/scripts/run_leo_container.sh
+++ b/scripts/run_leo_container.sh
@@ -15,11 +15,12 @@ if [[ -z $wid ]]; then
     docker pull ${IMAGE_NAME} > /dev/null 2>&1
     wid=$(docker run \
           --mount type=bind,source=${BDCAT_NOTEBOOKS_HOME},target=/home/jupyter-user/${CONTAINER_REPO_ROOT} \
+          -v ~/.config:/home/jupyter-user/.config \  # Inject gcloud credentials
           --name "${CONTAINER_NAME}" \
           -it -d \
           ${IMAGE_NAME})
 else
-	# use existing container
-	:
+    # use existing container
+    :
 fi
 echo -n ${wid}


### PR DESCRIPTION
This removes the need to log in on ever run. However, it may
break with non-standard gcloud installation.