### PR TITLE
Fix BYOD.

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -13,7 +13,7 @@ byod:
     - pip install --no-cache-dir -r requirements-dev.txt
     - mkdir -p ~/.config/gcloud
     - cp $TEST_MULE_CREDENTIALS ~/.config/gcloud/application_default_credentials.json
-    - unset GOOGLE_APPLICATION_CREDENTIALS; export GOOGLE_PROJECT=firecloud-cgl; export WORKSPACE_NAME=terra-notebook-utils-tests
+    - unset GOOGLE_APPLICATION_CREDENTIALS
     - make cicd_notebooks/byod.py
 
 prepare_igv_viewer_input:
@@ -23,7 +23,7 @@ prepare_igv_viewer_input:
     - pip install --no-cache-dir -r requirements-dev.txt
     - mkdir -p ~/.config/gcloud
     - cp $TEST_MULE_CREDENTIALS ~/.config/gcloud/application_default_credentials.json
-    - unset GOOGLE_APPLICATION_CREDENTIALS; export GOOGLE_PROJECT=firecloud-cgl; export WORKSPACE_NAME=terra-notebook-utils-tests
+    - unset GOOGLE_APPLICATION_CREDENTIALS
     - make cicd_notebooks/prepare_igv_viewer_input.py
 
 vcf_merge_subsample_tutorial:
@@ -33,7 +33,7 @@ vcf_merge_subsample_tutorial:
     - pip install --no-cache-dir -r requirements-dev.txt
     - mkdir -p ~/.config/gcloud
     - cp $TEST_MULE_CREDENTIALS ~/.config/gcloud/application_default_credentials.json
-    - unset GOOGLE_APPLICATION_CREDENTIALS; export GOOGLE_PROJECT=firecloud-cgl; export WORKSPACE_NAME=terra-notebook-utils-tests
+    - unset GOOGLE_APPLICATION_CREDENTIALS
     - make cicd_notebooks/vcf_merge_subsample_tutorial.py
 
 xvcfmerge-array-input:
@@ -43,5 +43,5 @@ xvcfmerge-array-input:
     - pip install --no-cache-dir -r requirements-dev.txt
     - mkdir -p ~/.config/gcloud
     - cp $TEST_MULE_CREDENTIALS ~/.config/gcloud/application_default_credentials.json
-    - unset GOOGLE_APPLICATION_CREDENTIALS; export GOOGLE_PROJECT=firecloud-cgl; export WORKSPACE_NAME=terra-notebook-utils-tests
+    - unset GOOGLE_APPLICATION_CREDENTIALS
     - make cicd_notebooks/xvcfmerge_array_input.py

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -11,6 +11,7 @@ byod:
   script:
     - . /home/jupyter-user/miniconda/bin/activate
     - pip install --no-cache-dir -r requirements-dev.txt
+    - mkdir -p ~/.config/gcloud
     - cp $TEST_MULE_CREDENTIALS ~/.config/gcloud/application_default_credentials.json
     - unset GOOGLE_APPLICATION_CREDENTIALS; export GOOGLE_PROJECT=firecloud-cgl; export WORKSPACE_NAME=terra-notebook-utils-tests
     - make cicd_notebooks/byod.py

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -21,7 +21,9 @@ prepare_igv_viewer_input:
   script:
     - . /home/jupyter-user/miniconda/bin/activate
     - pip install --no-cache-dir -r requirements-dev.txt
-    - export GOOGLE_APPLICATION_CREDENTIALS=$TEST_MULE_CREDENTIALS
+    - mkdir -p ~/.config/gcloud
+    - cp $TEST_MULE_CREDENTIALS ~/.config/gcloud/application_default_credentials.json
+    - unset GOOGLE_APPLICATION_CREDENTIALS; export GOOGLE_PROJECT=firecloud-cgl; export WORKSPACE_NAME=terra-notebook-utils-tests
     - make cicd_notebooks/prepare_igv_viewer_input.py
 
 vcf_merge_subsample_tutorial:
@@ -29,7 +31,9 @@ vcf_merge_subsample_tutorial:
   script:
     - . /home/jupyter-user/miniconda/bin/activate
     - pip install --no-cache-dir -r requirements-dev.txt
-    - export GOOGLE_APPLICATION_CREDENTIALS=$TEST_MULE_CREDENTIALS
+    - mkdir -p ~/.config/gcloud
+    - cp $TEST_MULE_CREDENTIALS ~/.config/gcloud/application_default_credentials.json
+    - unset GOOGLE_APPLICATION_CREDENTIALS; export GOOGLE_PROJECT=firecloud-cgl; export WORKSPACE_NAME=terra-notebook-utils-tests
     - make cicd_notebooks/vcf_merge_subsample_tutorial.py
 
 xvcfmerge-array-input:
@@ -37,5 +41,7 @@ xvcfmerge-array-input:
   script:
     - . /home/jupyter-user/miniconda/bin/activate
     - pip install --no-cache-dir -r requirements-dev.txt
-    - export GOOGLE_APPLICATION_CREDENTIALS=$TEST_MULE_CREDENTIALS
+    - mkdir -p ~/.config/gcloud
+    - cp $TEST_MULE_CREDENTIALS ~/.config/gcloud/application_default_credentials.json
+    - unset GOOGLE_APPLICATION_CREDENTIALS; export GOOGLE_PROJECT=firecloud-cgl; export WORKSPACE_NAME=terra-notebook-utils-tests
     - make cicd_notebooks/xvcfmerge_array_input.py

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -11,9 +11,8 @@ byod:
   script:
     - . /home/jupyter-user/miniconda/bin/activate
     - pip install --no-cache-dir -r requirements-dev.txt
-    - mkdir -p ~/.config/gcloud
     - cp $TEST_MULE_CREDENTIALS ~/.config/gcloud/application_default_credentials.json
-    - export GOOGLE_APPLICATION_CREDENTIALS=$TEST_MULE_CREDENTIALS
+    - unset GOOGLE_APPLICATION_CREDENTIALS; export GOOGLE_PROJECT=firecloud-cgl; export WORKSPACE_NAME=terra-notebook-utils-tests
     - make cicd_notebooks/byod.py
 
 prepare_igv_viewer_input:
@@ -37,7 +36,5 @@ xvcfmerge-array-input:
   script:
     - . /home/jupyter-user/miniconda/bin/activate
     - pip install --no-cache-dir -r requirements-dev.txt
-    - mkdir -p ~/.config/gcloud
-    - cp $TEST_MULE_CREDENTIALS ~/.config/gcloud/application_default_credentials.json
     - export GOOGLE_APPLICATION_CREDENTIALS=$TEST_MULE_CREDENTIALS
     - make cicd_notebooks/xvcfmerge_array_input.py

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -13,7 +13,6 @@ byod:
     - pip install --no-cache-dir -r requirements-dev.txt
     - mkdir -p ~/.config/gcloud
     - cp $TEST_MULE_CREDENTIALS ~/.config/gcloud/application_default_credentials.json
-    - unset GOOGLE_APPLICATION_CREDENTIALS
     - make cicd_notebooks/byod.py
 
 prepare_igv_viewer_input:
@@ -23,7 +22,6 @@ prepare_igv_viewer_input:
     - pip install --no-cache-dir -r requirements-dev.txt
     - mkdir -p ~/.config/gcloud
     - cp $TEST_MULE_CREDENTIALS ~/.config/gcloud/application_default_credentials.json
-    - unset GOOGLE_APPLICATION_CREDENTIALS
     - make cicd_notebooks/prepare_igv_viewer_input.py
 
 vcf_merge_subsample_tutorial:
@@ -33,7 +31,6 @@ vcf_merge_subsample_tutorial:
     - pip install --no-cache-dir -r requirements-dev.txt
     - mkdir -p ~/.config/gcloud
     - cp $TEST_MULE_CREDENTIALS ~/.config/gcloud/application_default_credentials.json
-    - unset GOOGLE_APPLICATION_CREDENTIALS
     - make cicd_notebooks/vcf_merge_subsample_tutorial.py
 
 xvcfmerge-array-input:
@@ -43,5 +40,4 @@ xvcfmerge-array-input:
     - pip install --no-cache-dir -r requirements-dev.txt
     - mkdir -p ~/.config/gcloud
     - cp $TEST_MULE_CREDENTIALS ~/.config/gcloud/application_default_credentials.json
-    - unset GOOGLE_APPLICATION_CREDENTIALS
     - make cicd_notebooks/xvcfmerge_array_input.py

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -11,8 +11,9 @@ byod:
   script:
     - . /home/jupyter-user/miniconda/bin/activate
     - pip install --no-cache-dir -r requirements-dev.txt
+    - mkdir -p ~/.config/gcloud
+    - cp $TEST_MULE_CREDENTIALS ~/.config/gcloud/application_default_credentials.json
     - export GOOGLE_APPLICATION_CREDENTIALS=$TEST_MULE_CREDENTIALS
-    - export GOOGLE_PROJECT=firecloud-cgl
     - make cicd_notebooks/byod.py
 
 prepare_igv_viewer_input:
@@ -36,5 +37,7 @@ xvcfmerge-array-input:
   script:
     - . /home/jupyter-user/miniconda/bin/activate
     - pip install --no-cache-dir -r requirements-dev.txt
+    - mkdir -p ~/.config/gcloud
+    - cp $TEST_MULE_CREDENTIALS ~/.config/gcloud/application_default_credentials.json
     - export GOOGLE_APPLICATION_CREDENTIALS=$TEST_MULE_CREDENTIALS
     - make cicd_notebooks/xvcfmerge_array_input.py

--- a/notebooks/byod.py
+++ b/notebooks/byod.py
@@ -239,7 +239,6 @@ with callysto.Cell("markdown"):
     """
 
 with callysto.Cell("python"):
-    os.environ['GOOGLE_PROJECT'] = "firecloud-cgl"
     listing = [key for key in gs.list_bucket(subdirectory)]
     create_cram_crai_table("my-table-name", listing)
 

--- a/notebooks/byod.py
+++ b/notebooks/byod.py
@@ -150,6 +150,7 @@ with callysto.Cell("markdown"):
 with callysto.Cell("python"):
     bucket = os.environ["WORKSPACE_BUCKET"]
     print(bucket)
+
 with callysto.Cell("markdown"):
     """
     ### Add a prefix to your bucket path to organize your data
@@ -161,6 +162,7 @@ with callysto.Cell("markdown"):
     """
 with callysto.Cell("python"):
     subdirectory = "my-crams"
+
 with callysto.Cell("markdown"):
     """
     #### A technical note on subdirectories in Google Cloud
@@ -237,8 +239,10 @@ with callysto.Cell("markdown"):
     """
 
 with callysto.Cell("python"):
+    os.environ['GOOGLE_PROJECT'] = "firecloud-cgl"
     listing = [key for key in gs.list_bucket(subdirectory)]
     create_cram_crai_table("my-table-name", listing)
+
 with callysto.Cell("markdown"):
     """
     Now, go check the data section of your workspace. You should see a data table with the name you have given it,


### PR DESCRIPTION
Problem: `terra-notebook-utils` doesn't authenticate if `GOOGLE_APPLICATION_CREDENTIALS` is set and is not a service account (the error produced is "project not found").  Our CI/CD uses non-service account credentials and in order for `terra-notebook-utils` to find them, this unsets `GOOGLE_APPLICATION_CREDENTIALS`.

To see the original breakage: https://biodata-integration-tests.net/databiosphere/bdcat_notebooks/-/jobs/1447