### PR TITLE
Remove common.mk

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,3 @@
-include common.mk
-
 MODULES=notebooks
 CONTAINER=$(shell ./scripts/run_leo_container.sh)
 LOCAL_ROOT_DIR:=$(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))

--- a/common.mk
+++ b/common.mk
@@ -1,3 +1,0 @@
-ifeq ($(findstring Python 3.8, $(shell python --version 2>&1)),)
-$(error Please run make commands from a Python 3.8 virtualenv)
-endif


### PR DESCRIPTION
Since we're testing in Docker containers it seems pointless to
verify correct Python virtual environments.