### PR TITLE
Re-introduce parallel CI/CD jobs

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -24,20 +24,20 @@ verify-gitlab-yml:
 
 byod:
   extends: .notebook-test
-  script: make cicd_tests/byod
+  script: make cicd_test/byod
 
 prepare_igv_viewer_input:
   extends: .notebook-test
-  script: make cicd_tests/prepare_igv_viewer_input
+  script: make cicd_test/prepare_igv_viewer_input
 
 vcf_merge_subsample_tutorial:
   extends: .notebook-test
-  script: make cicd_tests/vcf_merge_subsample_tutorial
+  script: make cicd_test/vcf_merge_subsample_tutorial
 
 workflow_cost_estimator:
   extends: .notebook-test
-  script: make cicd_tests/workflow_cost_estimator
+  script: make cicd_test/workflow_cost_estimator
 
 xvcfmerge_array_input:
   extends: .notebook-test
-  script: make cicd_tests/xvcfmerge_array_input
+  script: make cicd_test/xvcfmerge_array_input

--- a/Makefile
+++ b/Makefile
@@ -37,8 +37,8 @@ $(TESTS):
 $(CICD_TESTS):
 	$(MAKE) $(@:cicd_test/%=lint/%)
 	$(MAKE) $(@:cicd_test/%=mypy/%)
-	${LEO_PIP} install --upgrade -r $(@:cicd_tests/%=notebooks/%)/requirements.txt
-	${LEO_PYTHON} $(@:cicd_tests/%=notebooks/%)/main.py
+	${LEO_PIP} install --upgrade -r $(@:cicd_test/%=notebooks/%)/requirements.txt
+	${LEO_PYTHON} $(@:cicd_test/%=notebooks/%)/main.py
 	$(MAKE) $(@:cicd_test/%=notebooks/%/notebook.ipynb)
 
 $(LINT):

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ CICD_TESTS=$(subst notebooks,cicd_test,$(NOTEBOOK_DIRS))  # cicd_test targets: "
 
 all: test
 
-test: $(TESTS)
+test: verify-gitlab-yml $(TESTS)
 
 lint: $(LINT)
 
@@ -37,8 +37,8 @@ $(TESTS):
 $(CICD_TESTS):
 	$(MAKE) $(@:cicd_test/%=lint/%)
 	$(MAKE) $(@:cicd_test/%=mypy/%)
-	pip install --upgrade -r $(@:cicd_test/%=notebooks/%/requirements.txt)
-	python $(@:cicd_test/%=notebooks/%/main.py)
+	${LEO_PIP} install --upgrade -r $(@:cicd_tests/%=notebooks/%)/requirements.txt
+	${LEO_PYTHON} $(@:cicd_tests/%=notebooks/%)/main.py
 	$(MAKE) $(@:cicd_test/%=notebooks/%/notebook.ipynb)
 
 $(LINT):
@@ -47,10 +47,17 @@ $(LINT):
 $(MYPY):
 	mypy --ignore-missing-imports --no-strict-optional $(@:mypy/%=notebooks/%)
 
+.gitlab-ci.yml:
+	scripts/generate_gitlab_yml.sh .gitlab-ci.yml
+
+verify-gitlab-yml:
+	scripts/generate_gitlab_yml.sh test_gitlab_yml
+	diff .gitlab-ci.yml test_gitlab_yml
+
 clean_notebooks:
 	git clean -dfX notebooks
 
 clean:
 	git clean -dfx
 
-.PHONY: publish $(NOTEBOOK_DIRS) $(NOTEBOOKS) $(PUBLISH) $(TESTS) $(CICD_TESTS) clean clean_notebooks
+.PHONY: .gitlab-ci.yml $(NOTEBOOK_DIRS) $(NOTEBOOKS) $(PUBLISH) $(TESTS) $(CICD_TESTS) clean clean_notebooks

--- a/scripts/generate_gitlab_yml.sh
+++ b/scripts/generate_gitlab_yml.sh
@@ -44,5 +44,5 @@ for nb in $(find notebooks -mindepth 1 -maxdepth 1 -type d -print0 | sort -z | x
     echo "" >> ${out}
     echo "$(basename ${nb}):" >> ${out}
     echo "  extends: .notebook-test" >> ${out}
-    echo "  script: make cicd_tests/$(basename ${nb})" >> ${out}
+    echo "  script: make cicd_test/$(basename ${nb})" >> ${out}
 done


### PR DESCRIPTION
Parallelizing CI/CD jobs, with individual status reporting for each notebook, was a good idea, and was initially introduced in #30 

This brings it back with additional features:
  - A script `scripts/generate_gitlab_yml.sh` is introduced to generate the GitLab CI/CD configuration file `.gitlab-ci.yml`.
  - `make test` verifies that `.gitlab-ci.yml` is up to date (ensuring it includes all notebooks).
  - CI/CD fails immediately if `.gitlab-ci.yml` is out of date