### PR TITLE
Update the first GWAS BP notebook

### DIFF
--- a/notebooks/GWAS_blood_pressure_p1/main.py
+++ b/notebooks/GWAS_blood_pressure_p1/main.py
@@ -7,30 +7,39 @@ import herzog
 
 with herzog.Cell("markdown"):
 	"""
+	# Unarchive VCF tar bundles
+
+	## Goal of this notebook
+	Gen3 uploaded tar compressed bundles, as they are provided by dbGAP, into cloud buckets owned by BioData Catalyst. In order to make these tar files actionable and ready for use in an analysis, users will need to run this notebook to unarchive the tar files. Please understand that this step may be time consuming since TOPMed multi-sample VCF files are several hundred gigabytes in size. 
+
+	If you do not wish to use this option, you can use your credentials to download these files directly from dbGAP, extract them locally, and upload them to your Terra workspace. 
+	"""
+
+with herzog.Cell("markdown"):
+	"""
 	# Set up your notebook
 	----
 
 	## Set runtime values
-	If you are opening this notebook for the first time, and you did not edit your runtime settings before starting it, you will now need to change your settings. Click on the gear icon in the upper right to edit your Notebook Runtime. Set the values as specified below: 
+	If you are opening this notebook for the first time, and you did not edit your runtime settings before starting it, you may need to change your settings. Click on the gear icon in the upper right to edit your Notebook Runtime. Set the values as specified below: 
 
 	| Option | Value |
 	| ------ | ------ |
-	| Environment | New Default (Python 3.7.7) |
-	| Profile | Default (Moderate Compute Power) |
-	| Master CPUs | 4 |
-	| Master Memory | 15 GB |
-	| Master Disk size | 50 |
-	| Startup Script | leave blank |
+	| Application configuration | Default (GATK 4.1.4.1, Python 3.7.7, R 4.0.3) |
+	| CPUs | 4 |
+	| Memory (GB) | 15 |
+	| Startup Script | *leave blank* |
+	| Compute type | Standard VM |
+	| Persistent disk size (GB) | 50 |
+
 
 	Click the "Replace" button when you are done, and Terra will begin to create a new runtime with your settings. When it is finished, it will pop up asking you to apply the new settings.  
 
 	## Check kernel type  
 
-	A kernel is a _computational engine_ that executes the code in the notebook. You can think of it as defining the programming language. For this notebook, we'll use a `Python 3` kernel. In the upper right corner of the notebook, just under the Notebook Runtime, it should say `Python 3`. If it doesn't, you can switch it by navigating to the Kernel menu and selecting `Change kernel`.
+	A kernel is a _computational engine_ that executes the code in the notebook. You can think of it as defining the programming language. For this notebook, we'll use a `Python 3` kernel. In the upper right corner of the notebook, just under the Notebook Runtime, it should say `Python 3`. If it doesn't, you can switch it by navigating to the Kernel menu and selecting `Change kernel`. (Note that unlike runtime values, you will not be able to see the kernal if you are just viewing the notebook rather than running it.)
 
-	Gen3 uploaded tar compressed bundles, as they are provided by dbGAP, into cloud buckets owned by BioData Catalyst. In order to make these tar files actionable and ready for use in an analysis, users will need to run this notebook to unarchive the tar files. Please understand that this step may be time consuming since TOPMed multi-sample VCF files are several hundred gigabytes in size. 
-
-	If you do not wish to use this option, you can use your credentials to download these files directly from dbGAP, extract them locally, and upload them to your Terra workspace. 
+	## Additional tips
 
 	Learn more about [how not to lose data in notebooks](https://support.terra.bio/hc/en-us/articles/360027300571-Notebooks-101-How-not-to-lose-data-output-files). For tasks that take hours, like the ones below, we suggest keeping your computer connected to the internet so that you do not lose connection with the notebook VM and lose updates to the processes you started.
 


### PR DESCRIPTION
This is unrelated to the `pfb` related changes, just documentation updates.
The base branch is GWAS-bp, which is just a straight up herzogification of the notebook as is. This branch, compared to the base branch, only contains changes that I made beyond herzogification (ie, to the documentation).
I am not 100% sure what "moderate computer power" translates to in the new Terra UI, but I think that section in Terra's old UI just changed the other variables (memory, disk size, etc), ie, it was a template for changing multiple values at once. So in other words, a straight deletion is fine.
Standard VM was selected because the alternative is spark clusters, which in the old UI was just a checkbox. I figure if this was meant to run as a spark cluster than the notebook would've mentioned that.